### PR TITLE
Making word-export more versatile

### DIFF
--- a/jquery.wordexport.js
+++ b/jquery.wordexport.js
@@ -1,7 +1,8 @@
 if (typeof jQuery !== "undefined" && typeof saveAs !== "undefined") {
     (function($) {
-        $.fn.wordExport = function(fileName) {
+        $.fn.wordExport = function(fileName, autoSaveAs) {
             fileName = typeof fileName !== 'undefined' ? fileName : "jQuery-Word-Export";
+            autoSaveAs = typeof autoSaveAs !== 'undefined' ? autoSaveAs : true;
             var static = {
                 mhtml: {
                     top: "Mime-Version: 1.0\nContent-Base: " + location.href + "\nContent-Type: Multipart/related; boundary=\"NEXT.ITEM-BOUNDARY\";type=\"text/html\"\n\n--NEXT.ITEM-BOUNDARY\nContent-Type: text/html; charset=\"utf-8\"\nContent-Location: " + location.href + "\n\n<!DOCTYPE html>\n<html>\n_html_</html>",
@@ -71,7 +72,10 @@ if (typeof jQuery !== "undefined" && typeof saveAs !== "undefined") {
             var blob = new Blob([fileContent], {
                 type: "application/msword;charset=utf-8"
             });
-            saveAs(blob, fileName + ".doc");
+            if (autoSaveAs) {
+                saveAs(blob, fileName + ".doc");
+            }
+            return blob;
         };
     })(jQuery);
 } else {


### PR DESCRIPTION
- Returning the blob since we might want to use it in our code
- Making the autoSaveAs optional, sometimes we want to simply get a blob and handle saving ourselves.

Use case where I needed it: I needed to create a zip folder with js-zip, and wanted to save .doc files inside the zip folder. Therefor, I needed the blobs create by word-export. I was never going to save the doc files, I wanted to save the zip file. This commit performs the necessary changes to support such a use case, and is also 100% backwards compatible.